### PR TITLE
Pull Request: Fix Path to VERSION File in build_and_push.sh

### DIFF
--- a/pihole-unbound/build_and_push.sh
+++ b/pihole-unbound/build_and_push.sh
@@ -14,7 +14,7 @@ if ! docker buildx inspect build &> /dev/null; then
 fi
 
 # Get the Pi-hole version from the VERSION file, or use environment variable if set
-PIHOLE_VER=${PIHOLE_VERSION:-$(cat VERSION)}
+PIHOLE_VER=${PIHOLE_VERSION:-$(cat ./pihole-unbound/VERSION)}
 
 # Define platforms to target
 PLATFORMS="linux/arm/v7,linux/arm64/v8,linux/amd64"


### PR DESCRIPTION
# Summary

This pull request addresses an issue in the `build_and_push.sh` script where the path to the `VERSION` file was incorrect. The script has been updated to correctly reference the `VERSION` file within the `pihole-unbound` directory, ensuring that the correct version is used during the build and push process.

## Changes Included

### Fixed Path to VERSION File:
- The `build_and_push.sh` script was updated to use `./pihole-unbound/VERSION` instead of just `VERSION`.
- This change ensures that the correct version is retrieved from the `VERSION` file within the `pihole-unbound` directory.

## Impact

- **Build and Push Process:** This fix ensures that the correct version of the Docker image is built and pushed to the GitHub Container Registry (GHCR) as intended.
- **Correct Version Tagging:** The Docker images will now be tagged with the accurate version number as specified in the `./pihole-unbound/VERSION` file.

## Testing and Validation

- The updated script was tested to confirm that the correct version is being used during the build and push process.
- The workflow was re-run to ensure that the Docker images are correctly tagged and pushed to GHCR.

## Additional Notes

- This fix resolves the build failure that occurred due to the incorrect path, allowing the build and push process to complete successfully.
